### PR TITLE
Typos: `include/swift/SIL/` & `include/swift/SILOptimizer/` -> `include`

### DIFF
--- a/include/swift/SIL/DebugUtils.h
+++ b/include/swift/SIL/DebugUtils.h
@@ -66,7 +66,7 @@ inline void deleteAllDebugUses(SILInstruction *inst) {
 /// This iterator filters out any debug (or non-debug) instructions from a range
 /// of uses, provided by the underlying ValueBaseUseIterator.
 /// If \p nonDebugInsts is true, then the iterator provides a view to all non-
-/// debug instructions. Otherwise it provides a view ot all debug-instructions.
+/// debug instructions. Otherwise it provides a view to all debug-instructions.
 template <bool nonDebugInsts> class DebugUseIterator {
 public:
   using iterator_category = std::forward_iterator_tag;
@@ -252,7 +252,7 @@ bool hasNonTrivialNonDebugTransitiveUsers(
 /// information about a VarDecl. This allows one to write high level code over
 /// the set of such instructions with greater correctness by using exhaustive
 /// switches, methods, and keeping it light weight by using *, -> operators to
-/// access functionality from the underlying instruction when eneded.
+/// access functionality from the underlying instruction when ended.
 class VarDeclCarryingInst {
 public:
   enum class Kind : uint8_t {

--- a/include/swift/SIL/InstructionUtils.h
+++ b/include/swift/SIL/InstructionUtils.h
@@ -218,7 +218,7 @@ SILValue getStaticOverloadForSpecializedPolymorphicBuiltin(BuiltinInst *bi);
 /// a tree of tuples.
 ///
 /// If visitor returns false, we stop processing early. We return true if we
-/// visited all of the tuple elements without the visitor returing false.
+/// visited all of the tuple elements without the visitor returning false.
 bool visitExplodedTupleType(SILType type,
                             llvm::function_ref<bool(SILType)> callback);
 
@@ -226,7 +226,7 @@ bool visitExplodedTupleType(SILType type,
 /// a tree of tuples.
 ///
 /// If visitor returns false, we stop processing early. We return true if we
-/// visited all of the tuple elements without the visitor returing false.
+/// visited all of the tuple elements without the visitor returning false.
 bool visitExplodedTupleValue(SILValue value,
                              llvm::function_ref<SILValue(SILValue, std::optional<unsigned>)> callback);
 

--- a/include/swift/SIL/OSSALifetimeCompletion.h
+++ b/include/swift/SIL/OSSALifetimeCompletion.h
@@ -46,7 +46,7 @@ class OSSALifetimeCompletion {
 
   DeadEndBlocks &deadEndBlocks;
 
-  // Cache intructions already handled by the recursive algorithm to avoid
+  // Cache instructions already handled by the recursive algorithm to avoid
   // recomputing their lifetimes.
   ValueSet completedValues;
 
@@ -88,7 +88,7 @@ public:
   /// values or borrow introducers.
   ///
   /// Currently \p boundary == {Boundary::Availability} is used by Mem2Reg and
-  /// TempRValueOpt and PredicatbleMemOpt to complete lexical enum values on
+  /// TempRValueOpt and PredictableMemOpt to complete lexical enum values on
   /// trivial paths.
   ///
   /// Returns true if any new instructions were created to complete the

--- a/include/swift/SIL/OwnershipUseVisitor.h
+++ b/include/swift/SIL/OwnershipUseVisitor.h
@@ -205,7 +205,7 @@ bool OwnershipUseVisitor<Impl>::visitLifetimeEndingUses(SILValue ssaDef) {
   case OwnershipKind::Any:
   case OwnershipKind::None:
   case OwnershipKind::Unowned:
-    llvm_unreachable("requires an owned or guaranteed orignalDef");
+    llvm_unreachable("requires an owned or guaranteed originalDef");
   }
   return true;
 }
@@ -361,7 +361,7 @@ bool OwnershipUseVisitor<Impl>::visitInteriorUses(SILValue ssaDef) {
   case OwnershipKind::Any:
   case OwnershipKind::None:
   case OwnershipKind::Unowned:
-    llvm_unreachable("requires an owned or guaranteed orignalDef");
+    llvm_unreachable("requires an owned or guaranteed originalDef");
   }
 }
 

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -630,7 +630,7 @@ struct BorrowedValue {
 
   /// Add this scope's live blocks into the PrunedLiveness result. This
   /// includes reborrow scopes that are reachable from this borrow scope but not
-  /// necessarilly dominated by the borrow scope.
+  /// necessarily dominated by the borrow scope.
   void computeTransitiveLiveness(MultiDefPrunedLiveness &liveness) const;
 
   /// Returns true if \p uses are completely within this borrow introducer's
@@ -717,7 +717,7 @@ struct BorrowedValue {
   }
 
   // Helpers to allow a BorrowedValue to easily be used as a SILValue
-  // programatically.
+  // programmatically.
   SILValue operator->() { return value; }
   SILValue operator->() const { return value; }
   SILValue operator*() { return value; }

--- a/include/swift/SIL/Projection.h
+++ b/include/swift/SIL/Projection.h
@@ -955,7 +955,7 @@ public:
   void getLiveLeafTypes(llvm::SmallVectorImpl<SILType> &OutArray) const {
     for (unsigned LeafIndex : LiveLeafIndices) {
       const ProjectionTreeNode *Node = getNode(LeafIndex);
-      assert(Node->IsLive && "We are only interested in leafs that are live");
+      assert(Node->IsLive && "We are only interested in leaves that are live");
       OutArray.push_back(Node->getType());
     }
   }
@@ -964,20 +964,20 @@ public:
       llvm::SmallVectorImpl<const ProjectionTreeNode *> &Out) const {
     for (unsigned LeafIndex : LiveLeafIndices) {
       const ProjectionTreeNode *Node = getNode(LeafIndex);
-      assert(Node->IsLive && "We are only interested in leafs that are live");
+      assert(Node->IsLive && "We are only interested in leaves that are live");
       Out.push_back(Node);
     }
   }
 
-  /// Return the number of live leafs in the projection.
+  /// Return the number of live leaves in the projection.
   unsigned getLiveLeafCount() const { return LiveLeafIndices.size(); }
 
   void createTreeFromValue(SILBuilder &B, SILLocation Loc, SILValue NewBase,
-                           llvm::SmallVectorImpl<SILValue> &Leafs) const;
+                           llvm::SmallVectorImpl<SILValue> &Leaves) const;
 
   void
   replaceValueUsesWithLeafUses(SILBuilder &B, SILLocation Loc,
-                               llvm::SmallVectorImpl<SILValue> &Leafs);
+                               llvm::SmallVectorImpl<SILValue> &Leaves);
 
   void getUsers(SmallPtrSetImpl<SILInstruction *> &users) const;
 

--- a/include/swift/SIL/PrunedLiveness.h
+++ b/include/swift/SIL/PrunedLiveness.h
@@ -231,7 +231,7 @@ public:
 
   /// Update this liveness result for a single use.
   ///
-  /// \p isUseBeforeDef is true if \p user occures before the first def in this
+  /// \p isUseBeforeDef is true if \p user occurs before the first def in this
   /// block. This indicates "liveness holes" inside the block, causing liveness
   /// to propagate to predecessors.
   IsLive updateForUse(SILInstruction *user, bool isUseBeforeDef) {
@@ -754,7 +754,7 @@ public:
   /// then the resulting liveness does not includes potentially non-dominated
   /// uses within the reborrow scope. If the summary returns something other
   /// than AddressUseKind::NonEscaping, then the resulting liveness does not
-  /// necessarilly encapsulate value ownership.
+  /// necessarily encapsulate value ownership.
   ///
   /// Warning: If OSSA lifetimes are incomplete, then destroy_values might not
   /// jointly-post dominate if dead-end blocks are present. Nested scopes may
@@ -844,7 +844,7 @@ public:
   /// then the resulting liveness does not includes potentially non-dominated
   /// uses within the reborrow scope. If the summary returns something other
   /// than AddressUseKind::NonEscaping, then the resulting liveness does not
-  /// necessarilly encapsulate value ownership.
+  /// necessarily encapsulate value ownership.
   ///
   /// Warning: If OSSA lifetimes are incomplete, then destroy_values might not
   /// jointly-post dominate if dead-end blocks are present. Nested scopes may

--- a/include/swift/SIL/SILBitfield.h
+++ b/include/swift/SIL/SILBitfield.h
@@ -158,7 +158,7 @@ public:
 ///       BitfieldRef<Container> container;
 ///
 ///       void performWithContainer(SILFunction *function) {
-///          BitfieldRef<Container>::StackState state(container, functon);
+///          BitfieldRef<Container>::StackState state(container, function);
 ///
 ///          assert(container->isValid());
 ///       }

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -414,7 +414,7 @@ public:
     return bbIter->second != OrigBB;
   }
 
-  /// Return the new block within the cloned region analagous to the given
+  /// Return the new block within the cloned region analogous to the given
   /// original block.
   ///
   /// Assumes that `isBlockCloned` is true.

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -428,7 +428,7 @@ class SILInstruction : public llvm::ilist_node<SILInstruction> {
 
   /// Total number of created and deleted SILInstructions.
   ///
-  /// Ideally, those counters would be inside SILModules to allow mutiple
+  /// Ideally, those counters would be inside SILModules to allow multiple
   /// SILModules (e.g. in different threads).
   static int NumCreatedInstructions;
   static int NumDeletedInstructions;
@@ -872,7 +872,7 @@ public:
   bool isTriviallyDuplicatable() const;
 
   /// Returns true if the instruction is only relevant for debug
-  /// informations and has no other impact on program semantics.
+  /// information and has no other impact on program semantics.
   bool isDebugInstruction() const {
     return getKind() == SILInstructionKind::DebugValueInst;
   }
@@ -5199,7 +5199,7 @@ class AssignOrInitInst
   VarDecl *Property;
 
   /// Marks all of the properties in `initializes(...)` list that
-  /// have been initialized before this intruction to help Raw SIL
+  /// have been initialized before this instruction to help Raw SIL
   /// lowering to emit destroys.
   llvm::BitVector Assignments;
 
@@ -5739,7 +5739,7 @@ public:
 /// memory region, before binding it to a contiguous region of type $T. This
 /// token has no purpose unless it is consumed be a rebind_memory instruction.
 ///
-/// Semantics: changes the type information assocated with a memory region. This
+/// Semantics: changes the type information associated with a memory region. This
 /// affects all memory operations that alias with the given region of memory,
 /// regardless of their type or address provenance. For optimizations that query
 /// side effects, this is equivalent to writing and immediately reading an
@@ -7982,7 +7982,7 @@ public:
 /// All of these instructions produce a Builtin.PackIndex value which
 /// can only be used in packs with a specific shape class.  In
 /// principle, that shape class could be reflected into the result type,
-/// but we actually need more structue than that in order to get the
+/// but we actually need more structure than that in order to get the
 /// type-safety properties we want.  It therefore makes more sense to
 /// enforce structural properties on pack-index derivation than try
 /// to go all-in on dependent types.
@@ -9826,7 +9826,7 @@ public:
   /// the payload.
   ///
   /// Postcondition: if the result is non-null, then each successor has zero or
-  /// one block arguments which represents the forwaded result.
+  /// one block arguments which represents the forwarded result.
   const Operand *forwardedOperand() const;
 
   Operand *forwardedOperand() {

--- a/include/swift/SIL/SILLinkage.h
+++ b/include/swift/SIL/SILLinkage.h
@@ -171,7 +171,7 @@ enum SerializedKind_t : uint8_t {
   /// It's also used to determine during SIL deserialization whether loadable
   /// types in a serialized function can be allowed in the client module that
   /// imports the module built with Package CMO. If the client contains a [serialized]
-  /// function due to `@inlinable`, funtions with [serialized_for_package] from
+  /// function due to `@inlinable`, functions with [serialized_for_package] from
   /// the imported module are not allowed being inlined into the client function,
   /// which is the correct behavior.
   IsSerializedForPackage
@@ -306,7 +306,7 @@ inline bool hasPublicVisibility(SILLinkage linkage) {
 
 /// Opt in package linkage for visibility in case Package CMO is enabled.
 /// Used in SIL verification and other checks that determine inlinability to
-/// accomodate for the optimization.
+/// accommodate for the optimization.
 inline bool hasPublicOrPackageVisibility(SILLinkage linkage, bool includePackage) {
     switch (linkage) {
     case SILLinkage::Public:

--- a/include/swift/SIL/SILNodes.def
+++ b/include/swift/SIL/SILNodes.def
@@ -13,7 +13,7 @@
 /// \file
 ///
 /// This file defines macros used for macro-metaprogramming with SIL nodes. It
-/// supports changing how macros expand by #defining an auxillary variable
+/// supports changing how macros expand by #defining an auxiliary variable
 /// before including SILNodes.def as summarized in the chart below:
 ///
 /// | #define            | Operation                                           |

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -331,7 +331,7 @@ struct ValueOwnershipKind {
   /// Returns true if \p Other can be merged successfully with this, implying
   /// that the two ownership kinds are "compatible".
   ///
-  /// The reason why we do not compare directy is to allow for
+  /// The reason why we do not compare directly is to allow for
   /// OwnershipKind::None to merge into other forms of ValueOwnershipKind.
   bool isCompatibleWith(ValueOwnershipKind other) const {
     return bool(merge(other));

--- a/include/swift/SIL/ScopedAddressUtils.h
+++ b/include/swift/SIL/ScopedAddressUtils.h
@@ -87,7 +87,7 @@ struct ScopedAddressValue {
   SWIFT_DEBUG_DUMP { print(llvm::dbgs()); }
 
   // Helpers to allow a ScopedAddressValue to easily be used as a SILValue
-  // programatically.
+  // programmatically.
   SILValue operator->() { return value; }
   SILValue operator->() const { return value; }
   SILValue operator*() { return value; }

--- a/include/swift/SIL/Test.h
+++ b/include/swift/SIL/Test.h
@@ -254,7 +254,7 @@ private:
 private:
   /// Functions for getting tools that are visible in the SIL library.
   ///
-  /// The implementation is provided in the SILOptimizer libary where analyses
+  /// The implementation is provided in the SILOptimizer library where analyses
   /// are visible: TestRunner::FunctionTestDependenciesImpl.
   struct Dependencies {
     virtual DominanceInfo *getDominanceInfo() = 0;

--- a/include/swift/SILOptimizer/Analysis/Reachability.h
+++ b/include/swift/SILOptimizer/Analysis/Reachability.h
@@ -339,7 +339,7 @@ public:
 
   /// Step 4 (Optional): Visit each barrier instruction, phi, and block.
   ///
-  /// Effects are requeried.
+  /// Effects are required.
   ///
   /// A barrier block here means the target block of a barrier edge.
   ///

--- a/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
@@ -108,7 +108,7 @@ private:
   /// whether this changed the exit partition.
   ///
   /// NOTE: This method ignored errors that arise. We process separately later
-  /// to discover if an error occured.
+  /// to discover if an error occurred.
   bool recomputeExitFromEntry(PartitionOpTranslator &translator);
 };
 
@@ -357,7 +357,7 @@ private:
 public:
   RegionAnalysisValueMap(SILFunction *fn) : fn(fn) { }
 
-  /// Returns the value for this instruction if it isn't a fake "represenative
+  /// Returns the value for this instruction if it isn't a fake "representative
   /// value" to inject actor isolatedness. Asserts in such a case.
   SILValue getRepresentative(Element trackableValueID) const;
 

--- a/include/swift/SILOptimizer/OptimizerBridging.h
+++ b/include/swift/SILOptimizer/OptimizerBridging.h
@@ -105,11 +105,11 @@ struct BridgedCalleeAnalysis {
   SWIFT_IMPORT_UNSAFE CalleeList getDestructors(BridgedType type, bool isExactType) const;
 
   typedef bool (* _Nonnull IsDeinitBarrierFn)(BridgedInstruction, BridgedCalleeAnalysis bca);
-  typedef BridgedMemoryBehavior (* _Nonnull GetMemBehvaiorFn)(
+  typedef BridgedMemoryBehavior (* _Nonnull GetMemBehaviorFn)(
         BridgedInstruction apply, bool observeRetains, BridgedCalleeAnalysis bca);
 
   static void registerAnalysis(IsDeinitBarrierFn isDeinitBarrierFn,
-                               GetMemBehvaiorFn getEffectsFn);
+                               GetMemBehaviorFn getEffectsFn);
 };
 
 struct BridgedDeadEndBlocksAnalysis {
@@ -412,7 +412,7 @@ void SILCombine_registerInstructionPass(BridgedStringRef instClassName,
                                         BridgedInstructionPassRunFn runFn);
 
 #ifndef PURE_BRIDGING_MODE
-// In _not_ PURE_BRIDGING_MODE, briding functions are inlined and therefore inluded in the header file.
+// In _not_ PURE_BRIDGING_MODE, briding functions are inlined and therefore included in the header file.
 #include "OptimizerBridgingImpl.h"
 #else
 // For fflush and stdout

--- a/include/swift/SILOptimizer/Utils/InstructionDeleter.h
+++ b/include/swift/SILOptimizer/Utils/InstructionDeleter.h
@@ -87,7 +87,7 @@
 /// Note that the forceDelete* APIs only invoke notifyWillBeDeletedFunc() when
 /// an operand's definition will become dead after force-deleting the specified
 /// instruction. Some clients force-delete related instructions one at a
-/// time. It is the client's responsiblity to invoke notifyWillBeDeletedFunc()
+/// time. It is the client's responsibility to invoke notifyWillBeDeletedFunc()
 /// on those explicitly deleted instructions if needed.
 ///
 //===----------------------------------------------------------------------===//

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -347,7 +347,7 @@ struct TransferringOperandState {
   /// The dynamic isolation history at this point.
   IsolationHistory isolationHistory;
 
-  /// Set to true if the element associated with the operand's vlaue is closure
+  /// Set to true if the element associated with the operand's value is closure
   /// captured by the user. In such a case, if our element is a sendable var of
   /// a non-Sendable type, we cannot access it since we could race against an
   /// assignment to the var in a closure.
@@ -673,7 +673,7 @@ public:
   /// for.
   ///
   /// NOTE: This can only be used if one has cleared transfer state using
-  /// Partition::clearTransferState or constructed a new Partiton using
+  /// Partition::clearTransferState or constructed a new Partition using
   /// Partition::withoutTransferState(). This is because history rewinding
   /// doesn't use transfer information so just to be careful around potential
   /// invariants being broken, we just require the elimination of the transfer
@@ -716,7 +716,7 @@ public:
 
   /// Return a vector of the transferred values in this partition.
   std::vector<Element> getTransferredVals() const {
-    // For effeciency, this could return an iterator not a vector.
+    // For efficiency, this could return an iterator not a vector.
     std::vector<Element> transferredVals;
     for (auto [i, _] : elementToRegionMap)
       if (isTransferred(i))
@@ -727,7 +727,7 @@ public:
   /// Return a vector of the non-transferred regions in this partition, each
   /// represented as a vector of values.
   std::vector<std::vector<Element>> getNonTransferredRegions() const {
-    // For effeciency, this could return an iterator not a vector.
+    // For efficiency, this could return an iterator not a vector.
     std::map<Region, std::vector<Element>> buckets;
 
     for (auto [i, label] : elementToRegionMap)
@@ -818,7 +818,7 @@ private:
   /// Pop one history node. Multiple history nodes can make up one PartitionOp
   /// worth of history, so this is called by popHistory.
   ///
-  /// Returns true if we succesfully popped a single history node.
+  /// Returns true if we successfully popped a single history node.
   bool popHistoryOnce(SmallVectorImpl<IsolationHistory> &foundJoinHistoryNodes);
 
   /// A canonical region is defined to have its region number as equal to the
@@ -1109,7 +1109,7 @@ public:
 
       // Next see if we are disconnected and have the same isolation. In such a
       // case, we do not transfer since the disconnected value is allowed to be
-      // resued after we return.
+      // reused after we return.
       if (transferredRegionIsolation.isDisconnected() && calleeIsolationInfo &&
           transferredRegionIsolation.hasSameIsolation(calleeIsolationInfo))
         return;
@@ -1375,7 +1375,7 @@ struct PartitionOpEvaluatorBaseImpl : PartitionOpEvaluator<Subclass> {
       const PartitionOp &op, Element elt, Element otherElement,
       SILDynamicMergedIsolationInfo isolationRegionInfo) const {}
 
-  /// Used to signify an "unknown code pattern" has occured while performing
+  /// Used to signify an "unknown code pattern" has occurred while performing
   /// dataflow.
   ///
   /// DISCUSSION: Our dataflow cannot emit errors itself so this is a callback


### PR DESCRIPTION
Typos: `include/swift/SIL/` & `include/swift/SILOptimizer/` -> `include`